### PR TITLE
fix issue for heterogenuous block_size and layout

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1875,7 +1875,7 @@ class NixlConnectorWorker:
                 block_size_ratio > 1 or self.enable_permute_local_kv
             ):
                 block_ids_for_blocksize_post_process[block_size_ratio].append(
-                    meta.local_physical_block_ids
+                    meta.local_physical_block_ids[0]
                 )
         for (
             block_size_ratio,
@@ -2151,7 +2151,7 @@ class NixlConnectorWorker:
             remote_block_ids = remote_block_ids[0]
             local_block_ids = self.get_mapped_blocks(
                 np.asarray(local_block_ids), block_size_ratio
-            )
+            ).tolist()
             if len(local_block_ids) > len(remote_block_ids):
                 # NOTE:
                 # get_mapped_blocks will always expand block_ids for n times.
@@ -2165,8 +2165,8 @@ class NixlConnectorWorker:
                 # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] to
                 # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
                 local_block_ids = local_block_ids[: len(remote_block_ids)]
-            local_block_ids = tuple(local_block_ids) if local_block_ids else []
-            remote_block_ids = tuple(remote_block_ids)
+            local_block_ids = [local_block_ids] if local_block_ids else []
+            remote_block_ids = [remote_block_ids]
         # NOTE(rob): having the staging blocks be on the READER side is
         # not going to work well (since we will have to call rearrange tensors).
         # after we detect the txn is complete (which means we cannot make the


### PR DESCRIPTION
Fixes few issues when testing with heterogeneous setting on A100

codes are validated with cmdline below
```
DECODER_KV_LAYOUT=NHD PREFILL_BLOCK_SIZE=16 DECODE_BLOCK_SIZE=64 bash tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh 
```

```
PREFILL_BLOCK_SIZE=16 DECODE_BLOCK_SIZE=64 bash tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh 
```

```
DECODER_KV_LAYOUT=NHD bash tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
```



