### PR TITLE
[Bugfix] restore MLA notif request_id accidentally reverted in #40731

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -1962,7 +1962,7 @@ class NixlConnectorWorker:
         if self.use_mla and tp_ratio < 0 and read_specs:
             # ..but we still need to notify the other remote ranks that we
             # have the blocks we need so they can update the request state.
-            notif_id = f"{req_id}:{self.world_size}".encode()
+            notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
             remote_agents = self._remote_agents[meta.remote.engine_id]
             read_ranks = {s.remote_rank for s in read_specs}
             for rank_to_notify, agent in remote_agents.items():


### PR DESCRIPTION
One-line fix: use `meta.remote.request_id` instead of `req_id` for MLA broadcast notification to non-reading P-ranks.

Same fix as #40449, accidentally reverted during refactor #40731.
Fixes vllm-project/vllm#41974